### PR TITLE
add tests that cause decoding to panic

### DIFF
--- a/sszb_derive/tests/tests.rs
+++ b/sszb_derive/tests/tests.rs
@@ -88,3 +88,22 @@ fn struct_test() {
     }
     assert_eq!(b.to_ssz(), vec![255, 0b0000_0001]);
 }
+
+#[test]
+fn test_a() {
+    VariableB::from_ssz_bytes(&[]);
+}
+
+#[test]
+fn test_b() {
+    let bytes = vec![
+        2, 0, 89, 0, 0, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0,
+    ];
+    VariableB::from_ssz_bytes(&bytes);
+}
+
+#[test]
+fn test_c() {
+    let bytes = vec![0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0];
+    VariableB::from_ssz_bytes(&bytes);
+}


### PR DESCRIPTION
```
---- test_c stdout ----
thread 'test_c' panicked at /Users/x/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.8.0/src/lib.rs:138:5:
advance out of bounds: the len is 10 but advancing by 16

---- test_a stdout ----
thread 'test_a' panicked at sszb_derive/tests/tests.rs:31:28:
mid > len
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- test_b stdout ----
thread 'test_b' panicked at sszb_derive/tests/tests.rs:31:28:
attempt to subtract with overflow

```